### PR TITLE
fix/ get button with full width on default only

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,7 +21,6 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        // default size is full, use sm | lg for smaller sizes
         default: 'w-full h-9 px-4 py-2 has-[>svg]:px-3',
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',


### PR DESCRIPTION
Fixed the button size by making it full width only on default size variant, and then use _sm_ and _lg_ sizes for specific widths.
Did this so that we don't have to tweak the code in the login and signup forms, and  so that we can keep using full width buttons on forms by not specifying the size.